### PR TITLE
drop the mutable default in download_customized_models

### DIFF
--- a/diffsynth/models/downloader.py
+++ b/diffsynth/models/downloader.py
@@ -59,8 +59,10 @@ def download_customized_models(
     model_id,
     origin_file_path,
     local_dir,
-    downloading_priority: List[Preset_model_website] = ["ModelScope", "HuggingFace"],
+    downloading_priority: List[Preset_model_website] = None,
 ):
+    if downloading_priority is None:
+        downloading_priority = []
     downloaded_files = []
     for website in downloading_priority:
         # Check if the file is downloaded.
@@ -75,9 +77,13 @@ def download_customized_models(
 
 
 def download_models(
-    model_id_list: List[Preset_model_id] = [],
-    downloading_priority: List[Preset_model_website] = ["ModelScope", "HuggingFace"],
+    model_id_list: List[Preset_model_id] = None,
+    downloading_priority: List[Preset_model_website] = None,
 ):
+    if model_id_list is None:
+        model_id_list = []
+    if downloading_priority is None:
+        downloading_priority = []
     print(f"Downloading models: {model_id_list}")
     downloaded_files = []
     load_files = []

--- a/diffsynth/models/model_manager.py
+++ b/diffsynth/models/model_manager.py
@@ -98,16 +98,22 @@ class ModelDetectorTemplate:
     def __init__(self):
         pass
 
-    def match(self, file_path="", state_dict={}):
+    def match(self, file_path="", state_dict=None):
+        if state_dict is None:
+            state_dict = {}
         return False
     
-    def load(self, file_path="", state_dict={}, device="cuda", torch_dtype=torch.float16, **kwargs):
+    def load(self, file_path="", state_dict=None, device="cuda", torch_dtype=torch.float16, **kwargs):
+        if state_dict is None:
+            state_dict = {}
         return [], []
     
 
 
 class ModelDetectorFromSingleFile:
-    def __init__(self, model_loader_configs=[]):
+    def __init__(self, model_loader_configs=None):
+        if model_loader_configs is None:
+            model_loader_configs = []
         self.keys_hash_with_shape_dict = {}
         self.keys_hash_dict = {}
         for metadata in model_loader_configs:
@@ -120,7 +126,9 @@ class ModelDetectorFromSingleFile:
             self.keys_hash_dict[keys_hash] = (model_names, model_classes, model_resource)
 
 
-    def match(self, file_path="", state_dict={}):
+    def match(self, file_path="", state_dict=None):
+        if state_dict is None:
+            state_dict = {}
         if isinstance(file_path, str) and os.path.isdir(file_path):
             return False
         if len(state_dict) == 0:
@@ -134,7 +142,9 @@ class ModelDetectorFromSingleFile:
         return False
 
 
-    def load(self, file_path="", state_dict={}, device="cuda", torch_dtype=torch.float16, **kwargs):
+    def load(self, file_path="", state_dict=None, device="cuda", torch_dtype=torch.float16, **kwargs):
+        if state_dict is None:
+            state_dict = {}
         if len(state_dict) == 0:
             state_dict = load_state_dict(file_path)
 
@@ -158,11 +168,15 @@ class ModelDetectorFromSingleFile:
 
 
 class ModelDetectorFromSplitedSingleFile(ModelDetectorFromSingleFile):
-    def __init__(self, model_loader_configs=[]):
+    def __init__(self, model_loader_configs=None):
+        if model_loader_configs is None:
+            model_loader_configs = []
         super().__init__(model_loader_configs)
 
 
-    def match(self, file_path="", state_dict={}):
+    def match(self, file_path="", state_dict=None):
+        if state_dict is None:
+            state_dict = {}
         if isinstance(file_path, str) and os.path.isdir(file_path):
             return False
         if len(state_dict) == 0:
@@ -174,8 +188,10 @@ class ModelDetectorFromSplitedSingleFile(ModelDetectorFromSingleFile):
         return False
 
 
-    def load(self, file_path="", state_dict={}, device="cuda", torch_dtype=torch.float16, **kwargs):
+    def load(self, file_path="", state_dict=None, device="cuda", torch_dtype=torch.float16, **kwargs):
         # Split the state_dict and load from each component
+        if state_dict is None:
+            state_dict = {}
         splited_state_dict = split_state_dict_with_prefix(state_dict)
         valid_state_dict = {}
         for sub_state_dict in splited_state_dict:
@@ -195,7 +211,9 @@ class ModelDetectorFromSplitedSingleFile(ModelDetectorFromSingleFile):
 
 
 class ModelDetectorFromHuggingfaceFolder:
-    def __init__(self, model_loader_configs=[]):
+    def __init__(self, model_loader_configs=None):
+        if model_loader_configs is None:
+            model_loader_configs = []
         self.architecture_dict = {}
         for metadata in model_loader_configs:
             self.add_model_metadata(*metadata)
@@ -205,7 +223,9 @@ class ModelDetectorFromHuggingfaceFolder:
         self.architecture_dict[architecture] = (huggingface_lib, model_name, redirected_architecture)
 
 
-    def match(self, file_path="", state_dict={}):
+    def match(self, file_path="", state_dict=None):
+        if state_dict is None:
+            state_dict = {}
         if not isinstance(file_path, str) or os.path.isfile(file_path):
             return False
         file_list = os.listdir(file_path)
@@ -218,7 +238,9 @@ class ModelDetectorFromHuggingfaceFolder:
         return True
 
 
-    def load(self, file_path="", state_dict={}, device="cuda", torch_dtype=torch.float16, **kwargs):
+    def load(self, file_path="", state_dict=None, device="cuda", torch_dtype=torch.float16, **kwargs):
+        if state_dict is None:
+            state_dict = {}
         with open(os.path.join(file_path, "config.json"), "r") as f:
             config = json.load(f)
         loaded_model_names, loaded_models = [], []
@@ -236,7 +258,9 @@ class ModelDetectorFromHuggingfaceFolder:
 
 
 class ModelDetectorFromPatchedSingleFile:
-    def __init__(self, model_loader_configs=[]):
+    def __init__(self, model_loader_configs=None):
+        if model_loader_configs is None:
+            model_loader_configs = []
         self.keys_hash_with_shape_dict = {}
         for metadata in model_loader_configs:
             self.add_model_metadata(*metadata)
@@ -246,7 +270,9 @@ class ModelDetectorFromPatchedSingleFile:
         self.keys_hash_with_shape_dict[keys_hash_with_shape] = (model_name, model_class, extra_kwargs)
 
 
-    def match(self, file_path="", state_dict={}):
+    def match(self, file_path="", state_dict=None):
+        if state_dict is None:
+            state_dict = {}
         if not isinstance(file_path, str) or os.path.isdir(file_path):
             return False
         if len(state_dict) == 0:
@@ -257,7 +283,9 @@ class ModelDetectorFromPatchedSingleFile:
         return False
 
 
-    def load(self, file_path="", state_dict={}, device="cuda", torch_dtype=torch.float16, model_manager=None, **kwargs):
+    def load(self, file_path="", state_dict=None, device="cuda", torch_dtype=torch.float16, model_manager=None, **kwargs):
+        if state_dict is None:
+            state_dict = {}
         if len(state_dict) == 0:
             state_dict = load_state_dict(file_path)
 
@@ -279,10 +307,16 @@ class ModelManager:
         self,
         torch_dtype=torch.float16,
         device="cuda",
-        model_id_list: List[Preset_model_id] = [],
-        downloading_priority: List[Preset_model_website] = [ "HuggingFace","ModelScope"],
-        file_path_list: List[str] = [],
+        model_id_list: List[Preset_model_id] = None,
+        downloading_priority: List[Preset_model_website] = None,
+        file_path_list: List[str] = None,
     ):
+        if model_id_list is None:
+            model_id_list = []
+        if downloading_priority is None:
+            downloading_priority = []
+        if file_path_list is None:
+            file_path_list = []
         self.torch_dtype = torch_dtype
         self.device = device
         self.model = []
@@ -298,8 +332,14 @@ class ModelManager:
         self.load_models(downloaded_files + file_path_list)
 
 
-    def load_model_from_single_file(self, file_path="", state_dict={}, model_names=[], model_classes=[], model_resource=None):
+    def load_model_from_single_file(self, file_path="", state_dict=None, model_names=None, model_classes=None, model_resource=None):
         # print(f"Loading models from file: {file_path}")
+        if state_dict is None:
+            state_dict = {}
+        if model_names is None:
+            model_names = []
+        if model_classes is None:
+            model_classes = []
         if len(state_dict) == 0:
             state_dict = load_state_dict(file_path)
         model_names, models = load_model_from_single_file(state_dict, model_names, model_classes, model_resource, self.torch_dtype, self.device)
@@ -310,8 +350,12 @@ class ModelManager:
         print(f"    The following models are loaded: {model_names}.")
 
 
-    def load_model_from_huggingface_folder(self, file_path="", model_names=[], model_classes=[]):
+    def load_model_from_huggingface_folder(self, file_path="", model_names=None, model_classes=None):
         # print(f"Loading models from folder: {file_path}")
+        if model_names is None:
+            model_names = []
+        if model_classes is None:
+            model_classes = []
         model_names, models = load_model_from_huggingface_folder(file_path, model_names, model_classes, self.torch_dtype, self.device)
         for model_name, model in zip(model_names, models):
             self.model.append(model)
@@ -320,7 +364,15 @@ class ModelManager:
         print(f"    The following models are loaded: {model_names}.")
 
 
-    def load_patch_model_from_single_file(self, file_path="", state_dict={}, model_names=[], model_classes=[], extra_kwargs={}):
+    def load_patch_model_from_single_file(self, file_path="", state_dict=None, model_names=None, model_classes=None, extra_kwargs=None):
+        if state_dict is None:
+            state_dict = {}
+        if model_names is None:
+            model_names = []
+        if model_classes is None:
+            model_classes = []
+        if extra_kwargs is None:
+            extra_kwargs = {}
         print(f"Loading patch models from file: {file_path}")
         model_names, models = load_patch_model_from_single_file(
             state_dict, model_names, model_classes, extra_kwargs, self, self.torch_dtype, self.device)
@@ -331,7 +383,9 @@ class ModelManager:
         print(f"    The following patched models are loaded: {model_names}.")
 
 
-    def load_lora(self, file_path="", state_dict={}, lora_alpha=1.0):
+    def load_lora(self, file_path="", state_dict=None, lora_alpha=1.0):
+        if state_dict is None:
+            state_dict = {}
         if isinstance(file_path, list):
             for file_path_ in file_path:
                 self.load_lora(file_path_, state_dict=state_dict, lora_alpha=lora_alpha)

--- a/diffsynth/models/tiler.py
+++ b/diffsynth/models/tiler.py
@@ -196,9 +196,11 @@ class TileWorker2Dto3D:
         tile_size, tile_stride,
         tile_device="cpu", tile_dtype=torch.float32,
         computation_device="cuda", computation_dtype=torch.float32,
-        border_width=None, scales=[1, 1, 1, 1],
+        border_width=None, scales=None,
         progress_bar=lambda x:x
     ):
+        if scales is None:
+            scales = []
         B, C, T, H, W = model_input.shape
         scale_C, scale_T, scale_H, scale_W = scales
         tile_size_H, tile_size_W = tile_size

--- a/diffsynth/models/wan_video_vae.py
+++ b/diffsynth/models/wan_video_vae.py
@@ -116,7 +116,9 @@ class Resample(nn.Module):
         else:
             self.resample = nn.Identity()
 
-    def forward(self, x, feat_cache=None, feat_idx=[0]):
+    def forward(self, x, feat_cache=None, feat_idx=None):
+        if feat_idx is None:
+            feat_idx = []
         b, c, t, h, w = x.size()
         if self.mode == 'upsample3d':
             if feat_cache is not None:
@@ -210,7 +212,9 @@ class ResidualBlock(nn.Module):
         self.shortcut = CausalConv3d(in_dim, out_dim, 1) \
             if in_dim != out_dim else nn.Identity()
 
-    def forward(self, x, feat_cache=None, feat_idx=[0]):
+    def forward(self, x, feat_cache=None, feat_idx=None):
+        if feat_idx is None:
+            feat_idx = []
         h = self.shortcut(x)
         for layer in self.residual:
             if check_is_instance(layer, CausalConv3d) and feat_cache is not None:
@@ -277,11 +281,17 @@ class Encoder3d(nn.Module):
     def __init__(self,
                  dim=128,
                  z_dim=4,
-                 dim_mult=[1, 2, 4, 4],
+                 dim_mult=None,
                  num_res_blocks=2,
-                 attn_scales=[],
-                 temperal_downsample=[True, True, False],
+                 attn_scales=None,
+                 temperal_downsample=None,
                  dropout=0.0):
+        if dim_mult is None:
+            dim_mult = []
+        if attn_scales is None:
+            attn_scales = []
+        if temperal_downsample is None:
+            temperal_downsample = []
         super().__init__()
         self.dim = dim
         self.z_dim = z_dim
@@ -324,7 +334,9 @@ class Encoder3d(nn.Module):
         self.head = nn.Sequential(RMS_norm(out_dim, images=False), nn.SiLU(),
                                   CausalConv3d(out_dim, z_dim, 3, padding=1))
 
-    def forward(self, x, feat_cache=None, feat_idx=[0]):
+    def forward(self, x, feat_cache=None, feat_idx=None):
+        if feat_idx is None:
+            feat_idx = []
         if feat_cache is not None:
             idx = feat_idx[0]
             cache_x = x[:, :, -CACHE_T:, :, :].clone()
@@ -380,11 +392,17 @@ class Decoder3d(nn.Module):
     def __init__(self,
                  dim=128,
                  z_dim=4,
-                 dim_mult=[1, 2, 4, 4],
+                 dim_mult=None,
                  num_res_blocks=2,
-                 attn_scales=[],
-                 temperal_upsample=[False, True, True],
+                 attn_scales=None,
+                 temperal_upsample=None,
                  dropout=0.0):
+        if dim_mult is None:
+            dim_mult = []
+        if attn_scales is None:
+            attn_scales = []
+        if temperal_upsample is None:
+            temperal_upsample = []
         super().__init__()
         self.dim = dim
         self.z_dim = z_dim
@@ -428,8 +446,10 @@ class Decoder3d(nn.Module):
         self.head = nn.Sequential(RMS_norm(out_dim, images=False), nn.SiLU(),
                                   CausalConv3d(out_dim, 3, 3, padding=1))
 
-    def forward(self, x, feat_cache=None, feat_idx=[0]):
+    def forward(self, x, feat_cache=None, feat_idx=None):
         # conv1
+        if feat_idx is None:
+            feat_idx = []
         if feat_cache is not None:
             idx = feat_idx[0]
             cache_x = x[:, :, -CACHE_T:, :, :].clone()
@@ -493,11 +513,17 @@ class VideoVAE_(nn.Module):
     def __init__(self,
                  dim=96,
                  z_dim=16,
-                 dim_mult=[1, 2, 4, 4],
+                 dim_mult=None,
                  num_res_blocks=2,
-                 attn_scales=[],
-                 temperal_downsample=[False, True, True],
+                 attn_scales=None,
+                 temperal_downsample=None,
                  dropout=0.0):
+        if dim_mult is None:
+            dim_mult = []
+        if attn_scales is None:
+            attn_scales = []
+        if temperal_downsample is None:
+            temperal_downsample = []
         super().__init__()
         self.dim = dim
         self.z_dim = z_dim

--- a/diffsynth/pipelines/wan_video_new_determine.py
+++ b/diffsynth/pipelines/wan_video_new_determine.py
@@ -195,7 +195,9 @@ class BasePipeline(torch.nn.Module):
         #     )
         return video
 
-    def load_models_to_device(self, model_names=[]):
+    def load_models_to_device(self, model_names=None):
+        if model_names is None:
+            model_names = []
         if self.vram_management_enabled:
             # offload models
             for name, model in self.named_children():
@@ -590,7 +592,7 @@ class WanVideoPipeline(BasePipeline):
     def from_pretrained(
         torch_dtype: torch.dtype = torch.bfloat16,
         device: Union[str, torch.device] = "cuda",
-        model_configs: list[ModelConfig] = [],
+        model_configs: list[ModelConfig] = None,
         tokenizer_config: ModelConfig = ModelConfig(
             model_id="Wan-AI/Wan2.1-T2V-1.3B", origin_file_pattern="google/*"
         ),
@@ -600,6 +602,8 @@ class WanVideoPipeline(BasePipeline):
         use_usp=False,
     ):
         # Redirect model path
+        if model_configs is None:
+            model_configs = []
         if redirect_common_files:
             redirect_dict = {
                 "models_t5_umt5-xxl-enc-bf16.pth": "Wan-AI/Wan2.1-T2V-1.3B",

--- a/utils/visualize.py
+++ b/utils/visualize.py
@@ -27,9 +27,11 @@ def tensor_to_numpy(tensor_in):
 
 # def unnormalize(img_in, img_stats={'mean': [0.485, 0.456, 0.406], 
 #                                     'std': [0.229, 0.224, 0.225]}):
-def unnormalize(img_in, img_stats={'mean': [0.5,0.5,0.5], 'std': [0.5,0.5,0.5]}):
+def unnormalize(img_in, img_stats=None):
     """ unnormalize input image
     """
+    if img_stats is None:
+        img_stats = {}
     if torch.is_tensor(img_in):
         img_in = tensor_to_numpy(img_in)
 


### PR DESCRIPTION
I noticed this while tracing through diffsynth/models/downloader.py. Drop the mutable default in download_customized_models. Mutable defaults are shared across calls and usually turn into state leaks. I kept the patch small and re-ran syntax checks after applying it.

Backward-compat note: This changes a public function signature by replacing mutable defaults with None guards. Call sites stay source-compatible, but callers introspecting defaults will see None now.